### PR TITLE
gives more context to callbacks

### DIFF
--- a/Phasetips.js
+++ b/Phasetips.js
@@ -44,7 +44,7 @@ var Phasetips = function(localGame, options) {
         }
 
         if (_options.onHoverCallback) {
-            _options.onHoverCallback();
+            _options.onHoverCallback(_this);
         }
     };
 
@@ -62,7 +62,7 @@ var Phasetips = function(localGame, options) {
         }
 
         if (_options.onOutCallback) {
-            _options.onOutCallback();
+            _options.onOutCallback(_this);
         }
     };
 


### PR DESCRIPTION
usefull when you want for example put the mainGroup to the top of the world

ex: 

```
onHoverCallback: function (tip) { game.world.bringToTop(tip.mainGroup); }
```
