### PR TITLE
Exports

### DIFF
--- a/Phasetips.js
+++ b/Phasetips.js
@@ -263,3 +263,7 @@ var Phasetips = function(localGame, options) {
         }
     };
 };
+
+if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = Phasetips;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "phasetips",
+  "version": "1.0.0",
+  "description": "A tooltips plugin for Phaser.io game framework",
+  "main": "Phasetips.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netgfx/Phasetips.git"
+  },
+  "author": "netgfx",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/netgfx/Phasetips/issues"
+  },
+  "homepage": "https://github.com/netgfx/Phasetips#readme"
+}


### PR DESCRIPTION
This allows Phasetips to be imported in webpack and browserify. You can publish to npm if you want. Otherwise, we can have npm install it from github.