### PR TITLE
Added styling options and alwaysOn option

### DIFF
--- a/Phasetips.js
+++ b/Phasetips.js
@@ -85,6 +85,7 @@ var Phasetips = function(localGame, options) {
         // Option for rounded corners
         var _roundedCornersRadius = _options.roundedCornersRadius || 1;
         // Option for font style
+        var _font = _options.font || '';
         var _fontSize = _options.fontSize || 12;
         var _fontFill = _options.fontFill || "#FFFFFF";
         var _fontStroke = _options.fontStroke || "#232323";
@@ -93,6 +94,7 @@ var Phasetips = function(localGame, options) {
         var _fontWordWrapWidth = _options.fontWordWrapWidth || 200;
         // Text style properties
         var _textStyle = _options.textStyle || {
+            font: _font,
             fontSize: _fontSize,
             fill: _fontFill,
             stroke: _fontStroke,

--- a/Phasetips.js
+++ b/Phasetips.js
@@ -82,17 +82,23 @@ var Phasetips = function(localGame, options) {
         var _enableCursor = _options.enableCursor || false;
         var _customBackground = _options.customBackground || false;
         var _fixedToCamera = _options.fixedToCamera || false;
-        var _roundedCorderRadius = _options.roundedCorderRadius || 1;
+        // Option for rounded corners
+        var _roundedCornersRadius = _options.roundedCornersRadius || 1;
+        // Option for font style
         var _fontSize = _options.fontSize || 12;
         var _fontFill = _options.fontFill || "#FFFFFF";
         var _fontStroke = _options.fontStroke || "#232323";
+        var _fontStrokeThickness = _options.fontStrokeThickness || 1;
+        var _fontWordWrap = _options.fontWordWrap || true;
+        var _fontWordWrapWidth = _options.fontWordWrapWidth || 200;
+        // Text style properties
         var _textStyle = _options.textStyle || {
             fontSize: _fontSize,
             fill: _fontFill,
             stroke: _fontStroke,
-            strokeThickness: 1,
-            wordWrap: true,
-            wordWrapWidth: 200
+            strokeThickness: _fontStrokeThickness,
+            wordWrap: _fontWordWrap,
+            wordWrapWidth: _fontWordWrapWidth
         };
 
         //
@@ -105,7 +111,8 @@ var Phasetips = function(localGame, options) {
         var _animationSpeedHide = _options.animationSpeedHide || 200;
         var _onHoverCallback = _options.onHoverCallback || function() {};
         var _onOutCallback = _options.onOutCallback || function() {};
-
+        // If alwaysOn option is set to true, the tooltip will not fade in or out upon hover.
+        // Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip methods to manually control the visibility.
         var _alwaysOn = _options.alwaysOn || false;
 
         _options.animation = _animation;
@@ -238,7 +245,13 @@ var Phasetips = function(localGame, options) {
             tooltipBG.x = 0;
             tooltipBG.y = 0;
             tooltipBG.lineStyle(_strokeWeight, _strokeColor, 1);
-            tooltipBG.drawRoundedRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, _roundedCorderRadius);
+
+            // if drawRoundedRect method is not available or roundedCornersRadius option is set to 1, use drawRect
+            if(_roundedCornersRadius == 1 || !tooltipBG.drawRoundedRect) {
+                tooltipBG.drawRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, 1);
+            } else {
+                tooltipBG.drawRoundedRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, _roundedCornersRadius);
+            }
         } else {
             tooltipBG = _customBackground;
         }
@@ -292,6 +305,12 @@ var Phasetips = function(localGame, options) {
         showTooltip: function() {
             _this.mainGroup.visible = true;
             _this.mainGroup.alpha = 1;
+        },
+        simulateOnHoverOver: function () {
+            _this.onHoverOver();
+        },
+        simulateOnHoverOut: function () {
+            _this.onHoverOut();
         }
     };
 };

--- a/Phasetips.js
+++ b/Phasetips.js
@@ -270,12 +270,11 @@ var Phasetips = function(localGame, options) {
             _object.input.useHandCursor = true;
         }
 
-        if(_this.alwaysOn === false) {
+        if(_this.alwaysOn !== true) {
             _object.events.onInputOver.add(_this.onHoverOver, this);
             _object.events.onInputDown.add(_this.onHoverOver, this);
             _object.events.onInputOut.add(_this.onHoverOut, this);
             _object.events.onInputUp.add(_this.onHoverOut, this);
-            return;
         }
 
         mainGroup.update = function() {

--- a/Phasetips.js
+++ b/Phasetips.js
@@ -87,8 +87,8 @@ var Phasetips = function(localGame, options) {
         // Option for font style
         var _font = _options.font || '';
         var _fontSize = _options.fontSize || 12;
-        var _fontFill = _options.fontFill || "#FFFFFF";
-        var _fontStroke = _options.fontStroke || "#232323";
+        var _fontFill = _options.fontFill || "#ffffff";
+        var _fontStroke = _options.fontStroke || "#1e1e1e";
         var _fontStrokeThickness = _options.fontStrokeThickness || 1;
         var _fontWordWrap = _options.fontWordWrap || true;
         var _fontWordWrapWidth = _options.fontWordWrapWidth || 200;

--- a/Phasetips.js
+++ b/Phasetips.js
@@ -248,8 +248,8 @@ var Phasetips = function(localGame, options) {
             tooltipBG.y = 0;
             tooltipBG.lineStyle(_strokeWeight, _strokeColor, 1);
 
-            // if drawRoundedRect method is not available or roundedCornersRadius option is set to 1, use drawRect
-            if(_roundedCornersRadius == 1 || !tooltipBG.drawRoundedRect) {
+            // if roundedCornersRadius option is set to 1, drawRect will be used.
+            if( _roundedCornersRadius == 1 ) {
                 tooltipBG.drawRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, 1);
             } else {
                 tooltipBG.drawRoundedRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, _roundedCornersRadius);

--- a/Phasetips.js
+++ b/Phasetips.js
@@ -82,10 +82,14 @@ var Phasetips = function(localGame, options) {
         var _enableCursor = _options.enableCursor || false;
         var _customBackground = _options.customBackground || false;
         var _fixedToCamera = _options.fixedToCamera || false;
+        var _roundedCorderRadius = _options.roundedCorderRadius || 1;
+        var _fontSize = _options.fontSize || 12;
+        var _fontFill = _options.fontFill || "#FFFFFF";
+        var _fontStroke = _options.fontStroke || "#232323";
         var _textStyle = _options.textStyle || {
-            fontSize: 12,
-            fill: "#ffffff",
-            stroke: "#1e1e1e",
+            fontSize: _fontSize,
+            fill: _fontFill,
+            stroke: _fontStroke,
             strokeThickness: 1,
             wordWrap: true,
             wordWrapWidth: 200
@@ -101,6 +105,8 @@ var Phasetips = function(localGame, options) {
         var _animationSpeedHide = _options.animationSpeedHide || 200;
         var _onHoverCallback = _options.onHoverCallback || function() {};
         var _onOutCallback = _options.onOutCallback || function() {};
+
+        var _alwaysOn = _options.alwaysOn || false;
 
         _options.animation = _animation;
         _options.animationDelay = _animationDelay;
@@ -232,7 +238,7 @@ var Phasetips = function(localGame, options) {
             tooltipBG.x = 0;
             tooltipBG.y = 0;
             tooltipBG.lineStyle(_strokeWeight, _strokeColor, 1);
-            tooltipBG.drawRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, 1);
+            tooltipBG.drawRoundedRect(0, 0, tooltipContent.width + _padding, tooltipContent.height + _padding, _roundedCorderRadius);
         } else {
             tooltipBG = _customBackground;
         }
@@ -248,10 +254,14 @@ var Phasetips = function(localGame, options) {
         if (_enableCursor) {
             _object.input.useHandCursor = true;
         }
-        _object.events.onInputOver.add(_this.onHoverOver, this);
-        _object.events.onInputDown.add(_this.onHoverOver, this);
-        _object.events.onInputOut.add(_this.onHoverOut, this);
-        _object.events.onInputUp.add(_this.onHoverOut, this);
+
+        if(_this.alwaysOn === false) {
+            _object.events.onInputOver.add(_this.onHoverOver, this);
+            _object.events.onInputDown.add(_this.onHoverOver, this);
+            _object.events.onInputOut.add(_this.onHoverOut, this);
+            _object.events.onInputUp.add(_this.onHoverOut, this);
+            return;
+        }
 
         mainGroup.update = function() {
             var worldPos = _options.targetObject ? _options.targetObject.world : game.world;

--- a/README.md
+++ b/README.md
@@ -29,23 +29,24 @@ The game instance that we want the tooltips to appear to, such as "game"
 <strong>General Options:</strong>
 
 <ul>
-	<li><strong>context:</strong> The information inside the tooltip, can be String, Number, Sprite, Phaser.Text, Phaser.BitmapText, Phaser.Group, Phaser.Image</li>
-	<li><strong>width:</strong> The width of the tooltip (default: auto)</li>
-  <li><strong>height:</strong> The height of the tooltip (default: auto)</li>
-  <li><strong>x:</strong> The x position of the tooltip (default: auto based on position)</li>
-	<li><strong>y:</strong> The y position of the tooltip (default: auto based on position)</li>
-	<li><strong>targetObject:</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
-	<li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
-	<li><strong>alwaysOn:</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
+    <li><strong>context:</strong> The information inside the tooltip, can be String, Number, Sprite, Phaser.Text, Phaser.BitmapText, Phaser.Group, Phaser.Image</li>
+    <li><strong>width:</strong> The width of the tooltip (default: auto)</li>
+    <li><strong>height:</strong> The height of the tooltip (default: auto)</li>
+    <li><strong>x:</strong> The x position of the tooltip (default: auto based on position)</li>
+    <li><strong>y:</strong> The y position of the tooltip (default: auto based on position)</li>
+    <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
+    <li><strong>targetObject:</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
+    <li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
+    <li><strong>alwaysOn:</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
 </ul>
 
 <strong>Animation Options:</strong>
 
 <ul>
-  <li><strong>animation: </strong> The animation effect (default: fade, options:fade, grow, none)</li>
-  <li><strong>animationSpeedShow: </strong> The duration of the animation effect showing the tooltip (default: 300)</li>
-  <li><strong>animationSpeedHide: </strong> The duration of the animation effect hiding the tooltip (default: 200)</li>
-  <li><strong>animationDelay: </strong> The animation delay before showing the tooltip (default: 0)</li>
+    <li><strong>animation: </strong> The animation effect (default: fade, options:fade, grow, none)</li>
+    <li><strong>animationSpeedShow: </strong> The duration of the animation effect showing the tooltip (default: 300)</li>
+    <li><strong>animationSpeedHide: </strong> The duration of the animation effect hiding the tooltip (default: 200)</li>
+    <li><strong>animationDelay: </strong> The animation delay before showing the tooltip (default: 0)</li>
 </ul>
 
 <strong>Alignment Options:</strong>
@@ -64,7 +65,6 @@ The game instance that we want the tooltips to appear to, such as "game"
     <li><strong>strokeColor: </strong> The color of tooltip stroke (default: 0xffffff)</li>
     <li><strong>strokeWeight: </strong> The line weight of the tooltip stroke (default: 2)</li>
     <li><strong>customBackground: </strong> If the tooltip will use a custom background (default: false)</li>
-    <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
 </ul>
 
 <strong>Font Options:</strong>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please see the source code at : https://github.com/BeFiveINFO/Phasetips/blob/mas
 Example:
 
 ```
-this.tooltip_enter_name = new Phasetips(Game, {
+var tooltip_enter_name = new Phasetips(Game, {
 	targetObject: Register.spriteInstances.name_input_text_field_backpanel,
 	context: "Please enter your nickname to start game.",
 	fontSize: "24px Josefin Sans",
@@ -27,6 +27,14 @@ this.tooltip_enter_name = new Phasetips(Game, {
 	roundedCorderRadius: 10,
 	position: "left",
 	alwaysOn: true,
+});
+```
+
+To show / hide 
+```
+tooltip_enter_name.showTooltip(); 
+
+tooltip_enter_name.hideTooltip();
 ```
 
 Original: https://github.com/netgfx/Phasetips

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The game instance that we want the tooltips to appear to, such as "game"
 	<li><strong>alwaysOn</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
 </ul>
 
-<strong>Annimation Options:</strong>
+<strong>Animation Options:</strong>
 
 <ul>
   <li><strong>animation: </strong> The animation effect (default: fade, options:fade, grow, none)</li>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The game instance that we want the tooltips to appear to, such as "game"
   <li><strong>x</strong> The x position of the tooltip (default: auto based on position)</li>
 	<li><strong>y</strong> The y position of the tooltip (default: auto based on position)</li>
 	<li><strong>targetObject</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
+	<li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
 	<li><strong>alwaysOn</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
 </ul>
 
@@ -59,11 +60,11 @@ The game instance that we want the tooltips to appear to, such as "game"
 
 <ul>
     <li><strong>backgroundColor: </strong> The color of the background (default: 0x000000)</li>
+    <li><strong>roundedCornersRadius: </strong> Radius of the rectangle corners. Set to 1 to use a regular rectangle. (default: 1)</li>
     <li><strong>strokeColor: </strong> The color of tooltip stroke (default: 0xffffff)</li>
     <li><strong>strokeWeight: </strong> The line weight of the tooltip stroke (default: 2)</li>
     <li><strong>customBackground: </strong> If the tooltip will use a custom background (default: false)</li>
     <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
-    <li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
 </ul>
 
 <strong>Font Options:</strong>

--- a/README.md
+++ b/README.md
@@ -1,92 +1,30 @@
-# PhaseTips
-A tooltips UI component for Phaser.io Javascript library
+# PhaseTips New Features(?) Proposal
 
-<h3>Initialize the tooltip anywhere in your game</h3>
+Added options:
+- Rounded corners
+  - roundedCorderRadius
+- font styles
+  - fontSize
+  - fontStroke
+  - fontFill
+- roundedCorderRadius (always show tips. control with methods to show and hide)
+
+Example:
+
 ```
-var myTooltip = new Phasetips(gameInstance, options);
+this.tooltip_enter_name = new Phasetips(Game, {
+	targetObject: Register.spriteInstances.name_input_text_field_backpanel,
+	context: "Please enter your nickname to start game.",
+	fontSize: "24px Josefin Sans",
+	width: 180,
+	fontStroke: "#f45212",
+	fontFill: "#f8ce18",
+	backgroundColor: 0xf45212,
+	strokeColor: 0xf8ce18,
+	strokeWeight: 5,
+	roundedCorderRadius: 10,
+	position: "left",
+	alwaysOn: true,
 ```
-pass necesery options like: context (the object that launches the tooltip)
 
-```
-new Phasetips(gameInstance, {
-    targetObject: myObj,
-    context: "Hello tooltip",
-    strokeColor: 0xff0000
-  });
-```
-
-<hr>
-
-<img src="http://i221.photobucket.com/albums/dd22/djmid71/phasetips_zpsjtzerwxx.gif"/>
-
-<strong>View example: <a href="http://www.netgfx.com/trunk/games/tools/phasetips">Complete example</a></strong>
-
-  <hr>
-
-<strong>Game Instance</strong>
-The game instance that we want the tooltips to appear to, such as "game"
-
-<strong>General Options:</strong>
-
-<ul>
-	<li><strong>context:</strong> The information inside the tooltip, can be String, Number, Sprite, Phaser.Text, Phaser.BitmapText, Phaser.Group, Phaser.Image</li>
-	<li><strong>width:</strong> The width of the tooltip (default: auto)</li>
-  <li><strong>height:</strong> The height of the tooltip (default: auto)</li>
-  <li><strong>x</strong> The x position of the tooltip (default: auto based on position)</li>
-	<li><strong>y</strong> The y position of the tooltip (default: auto based on position)</li>
-	<li><strong>targetObject</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
-	<li><strong>animation: </strong> The animation effect (default: fade, options:fade, grow, none)</li>
-  <li><strong>animationSpeedShow: </strong> The duration of the animation effect showing the tooltip (default: 300)</li>
-  <li><strong>animationSpeedHide: </strong> The duration of the animation effect hiding the tooltip (default: 200)</li>
-  <li><strong>animationDelay: </strong> The animation delay before showing the tooltip (default: 0)</li>
-	<li><strong>padding: </strong> The padding that the context keeps from the tooltip bounds (default: 20)</li>
-    <li><strong>positionOffset: </strong> The position offset that the tooltip keeps from the targetObject (default: 20)</li>
-    <li><strong>backgroundColor: </strong> The color of the background (default: 0x000000)</li>
-    <li><strong>strokeColor: </strong> The color of tooltip stroke (default: 0xffffff)</li>
-    <li><strong>strokeWeight: </strong> The line weight of the tooltip stroke (default: 2)</li>
-    <li><strong>customBackground: </strong> If the tooltip will use a custom background (default: false)</li>
-    <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
-    <li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
-    <li><strong>textStyle: </strong> Declares styles for the simple text element (default: {
-            fontSize: 12,
-            fill: "#ffffff",
-            stroke: "#1e1e1e",
-            strokeThickness: 1,
-            wordWrap: true,
-            wordWrapWidth: 200,
-            lineSpacing: -2
-        }</li>
-    <li><strong>onHoverCallback: </strong> Calls a function when hover occurs (default: fn)</li>
-    <li><strong>onOutCallback: </strong> Calls a function when hover ends (default: fn)</li>
-    <li><strong>fixedToCamera: </strong> Pins the tooltip on the camera and moves with it (x,y are now camera offset) (default: false)</li>
-</ul>
-
-<strong>API Functions</strong>
-
-<ul>
-    <li><strong>printOptions: </strong> Prints the options specified in the constructor on the console</li>
-    <li><strong>updatePosition: </strong> Change the x, y of the tooltip</li>
-    <li><strong>destroy: </strong> Destroys the tooltip and all its children</li>
-    <li><strong>hideTooltip: </strong> Hide the tooltip</li>
-    <li><strong>showTooltip: </strong> Show the tooltip</li>
-</ul>
-
-<i>
-</i>
-
-<hr>
-
-<strong>Buy me a coffee or tea!</strong> <br>
-<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=JCFPKZJ7Y23JJ&lc=GR&item_name=NetGfx%2ecom&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted"><img src="https://www.paypalobjects.com/webstatic/en_US/btn/btn_donate_92x26.png"/></a>
-
-
-<hr>
-
->The TODO list is diminising!
-
->Please let me know if you come across some bug or have something to contribute
-
-
-
-
-
+Original: https://github.com/netgfx/Phasetips

--- a/README.md
+++ b/README.md
@@ -1,40 +1,137 @@
-# PhaseTips New Features(?) Proposal
+# PhaseTips
+A tooltips UI component for Phaser.io Javascript library
 
-Added options:
-- Rounded corners
-  - roundedCorderRadius
-- font styles
-  - fontSize
-  - fontStroke
-  - fontFill
-- roundedCorderRadius (always show tips. control with methods to show and hide)
-
-Please see the source code at : https://github.com/BeFiveINFO/Phasetips/blob/master/Phasetips.js
-
-Example:
+<h3>Initialize the tooltip anywhere in your game</h3>
+```
+var myTooltip = new Phasetips(gameInstance, options);
+```
+pass necesery options like: context (the object that launches the tooltip)
 
 ```
-var tooltip_enter_name = new Phasetips(Game, {
-	targetObject: Register.spriteInstances.name_input_text_field_backpanel,
-	context: "Please enter your nickname to start game.",
-	fontSize: "24px Josefin Sans",
-	width: 180,
-	fontStroke: "#f45212",
-	fontFill: "#f8ce18",
-	backgroundColor: 0xf45212,
-	strokeColor: 0xf8ce18,
-	strokeWeight: 5,
-	roundedCorderRadius: 10,
-	position: "left",
-	alwaysOn: true,
-});
+new Phasetips(gameInstance, {
+    targetObject: myObj,
+    context: "Hello tooltip",
+    strokeColor: 0xff0000
+  });
 ```
 
-To show / hide 
-```
-tooltip_enter_name.showTooltip(); 
+<hr>
 
-tooltip_enter_name.hideTooltip();
-```
+<img src="http://i221.photobucket.com/albums/dd22/djmid71/phasetips_zpsjtzerwxx.gif"/>
 
-Original: https://github.com/netgfx/Phasetips
+<strong>View example: <a href="http://www.netgfx.com/trunk/games/tools/phasetips">Complete example</a></strong>
+
+  <hr>
+
+<strong>Game Instance</strong>
+The game instance that we want the tooltips to appear to, such as "game"
+
+<strong>General Options:</strong>
+
+<ul>
+	<li><strong>context:</strong> The information inside the tooltip, can be String, Number, Sprite, Phaser.Text, Phaser.BitmapText, Phaser.Group, Phaser.Image</li>
+	<li><strong>width:</strong> The width of the tooltip (default: auto)</li>
+  <li><strong>height:</strong> The height of the tooltip (default: auto)</li>
+  <li><strong>x</strong> The x position of the tooltip (default: auto based on position)</li>
+	<li><strong>y</strong> The y position of the tooltip (default: auto based on position)</li>
+	<li><strong>targetObject</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
+	<li><strong>alwaysOn</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
+</ul>
+
+<strong>Annimation Options:</strong>
+
+<ul>
+  <li><strong>animation: </strong> The animation effect (default: fade, options:fade, grow, none)</li>
+  <li><strong>animationSpeedShow: </strong> The duration of the animation effect showing the tooltip (default: 300)</li>
+  <li><strong>animationSpeedHide: </strong> The duration of the animation effect hiding the tooltip (default: 200)</li>
+  <li><strong>animationDelay: </strong> The animation delay before showing the tooltip (default: 0)</li>
+</ul>
+
+<strong>Alignment Options:</strong>
+
+<ul>
+    <li><strong>padding: </strong> The padding that the context keeps from the tooltip bounds (default: 20)</li>
+    <li><strong>positionOffset: </strong> The position offset that the tooltip keeps from the targetObject (default: 20)</li>
+    <li><strong>fixedToCamera: </strong> Pins the tooltip on the camera and moves with it (x,y are now camera offset) (default: false)</li>
+</ul>
+
+<strong>Appearance Options:</strong>
+
+<ul>
+    <li><strong>backgroundColor: </strong> The color of the background (default: 0x000000)</li>
+    <li><strong>strokeColor: </strong> The color of tooltip stroke (default: 0xffffff)</li>
+    <li><strong>strokeWeight: </strong> The line weight of the tooltip stroke (default: 2)</li>
+    <li><strong>customBackground: </strong> If the tooltip will use a custom background (default: false)</li>
+    <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
+    <li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
+</ul>
+
+<strong>Font Options:</strong>
+
+It is also possible to define individual text style options.
+
+<ul>
+    <li><strong>font: </strong> The style and size of the font. This is overridden if you set any of the following font options. (default: '')</li>
+    <li><strong>fontSize: </strong> The size of the font. Accepts either string or number. eg. 12 or '12px' (default: 12)</li>
+    <li><strong>fontFill: </strong> A canvas fillstyle that will be used on the text eg 'red', '#00FF00'. (default: '#FFFFFF')</li>
+    <li><strong>fontStroke: </strong> A canvas stroke style that will be used on the text stroke eg 'blue', '#FCFF00'. (default: '#232323')</li>
+    <li><strong>fontStrokeThickness: </strong> A number that represents the thickness of the stroke. Set 0 for no stroke. (default: 1)</li>
+    <li><strong>fontWordWrap: </strong> Indicates if word wrap should be used. (default: true)</li>
+    <li><strong>fontWordWrapWidth: </strong> The width in pixels at which text will wrap. (default: 200)</li>
+</ul>
+
+<strong>Text Style Options:</strong>
+
+Set an object with respective properties to define all at once.
+
+<ul>
+    <li><strong>textStyle: </strong> Declares styles for the simple text element (default: {
+            font: '',
+            fontSize: 12,
+            fill: "#ffffff",
+            stroke: "#1e1e1e",
+            strokeThickness: 1,
+            wordWrap: true,
+            wordWrapWidth: 200,
+            lineSpacing: -2
+        }</li>
+</ul>
+
+<strong>Callback Options:</strong>
+
+<ul>
+    <li><strong>onHoverCallback: </strong> Calls a function when hover occurs (default: fn)</li>
+    <li><strong>onOutCallback: </strong> Calls a function when hover ends (default: fn)</li>
+</ul>
+
+<strong>API Functions</strong>
+
+<ul>
+    <li><strong>printOptions: </strong> Prints the options specified in the constructor on the console</li>
+    <li><strong>updatePosition: </strong> Change the x, y of the tooltip</li>
+    <li><strong>destroy: </strong> Destroys the tooltip and all its children</li>
+    <li><strong>hideTooltip: </strong> Hide the tooltip</li>
+    <li><strong>showTooltip: </strong> Show the tooltip</li>
+    <li><strong>simulateOnHoverOver: </strong> Simulates onHoverOver</li>
+    <li><strong>simulateOnHoverOut: </strong> Simulates onHoverOut</li>
+</ul>
+
+<i>
+</i>
+
+<hr>
+
+<strong>Buy me a coffee or tea!</strong> <br>
+<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=JCFPKZJ7Y23JJ&lc=GR&item_name=NetGfx%2ecom&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted"><img src="https://www.paypalobjects.com/webstatic/en_US/btn/btn_donate_92x26.png"/></a>
+
+
+<hr>
+
+>The TODO list is diminising!
+
+>Please let me know if you come across some bug or have something to contribute
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ The game instance that we want the tooltips to appear to, such as "game"
 	<li><strong>context:</strong> The information inside the tooltip, can be String, Number, Sprite, Phaser.Text, Phaser.BitmapText, Phaser.Group, Phaser.Image</li>
 	<li><strong>width:</strong> The width of the tooltip (default: auto)</li>
   <li><strong>height:</strong> The height of the tooltip (default: auto)</li>
-  <li><strong>x</strong> The x position of the tooltip (default: auto based on position)</li>
-	<li><strong>y</strong> The y position of the tooltip (default: auto based on position)</li>
-	<li><strong>targetObject</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
+  <li><strong>x:</strong> The x position of the tooltip (default: auto based on position)</li>
+	<li><strong>y:</strong> The y position of the tooltip (default: auto based on position)</li>
+	<li><strong>targetObject:</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
 	<li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
-	<li><strong>alwaysOn</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
+	<li><strong>alwaysOn:</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
 </ul>
 
 <strong>Animation Options:</strong>

--- a/README.md
+++ b/README.md
@@ -85,17 +85,20 @@ It is also possible to define individual text style options.
 Set an object with respective properties to define all at once.
 
 <ul>
-    <li><strong>textStyle: </strong> Declares styles for the simple text element (default: {
-            font: '',
-            fontSize: 12,
-            fill: "#ffffff",
-            stroke: "#1e1e1e",
-            strokeThickness: 1,
-            wordWrap: true,
-            wordWrapWidth: 200,
-            lineSpacing: -2
-        }</li>
+    <li><strong>textStyle: </strong> Declares styles for the simple text element. Default:</li>
 </ul>
+```
+{
+    font: '',
+    fontSize: 12,
+    fill: "#ffffff",
+    stroke: "#1e1e1e",
+    strokeThickness: 1,
+    wordWrap: true,
+    wordWrapWidth: 200,
+    lineSpacing: -2
+}
+```
 
 <strong>Callback Options:</strong>
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It is also possible to define individual text style options.
 Set an object with respective properties to define all at once.
 
 <ul>
-    <li><strong>textStyle: </strong> Declares styles for the simple text element. Default:</li>
+    <li><strong>textStyle: </strong> Declares styles for the simple text element. Individual font options above are overridden if the textStyle option is set. Default:</li>
 </ul>
 ```
 {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Added options:
   - fontFill
 - roundedCorderRadius (always show tips. control with methods to show and hide)
 
+Please see the source code at : https://github.com/BeFiveINFO/Phasetips/blob/master/Phasetips.js
+
 Example:
 
 ```

--- a/fixedToCamera.js
+++ b/fixedToCamera.js
@@ -103,6 +103,17 @@ GameState.prototype.create = function () {
     position: "left"
   });
 
+  var tip5 = new Phasetips(_game, {
+    targetObject: block1,
+    positionOffset: 180,
+    context: "This is a custom tip with rounded corners!",
+    roundedCornersRadius: 10,
+    strokeWeight: 5,
+    position: "left",
+    fontSize: 14
+  });
+
+
   tip1.printOptions();
 
   window.console.log(_game, slider);


### PR DESCRIPTION
Please ignore README.md, as I modified the file for leaving a brief summary memo of changes.

Changes made to the  Phasetips.js are:

1. Flexible pinpoint Text Style Options
2. roundedCornersRadius with fallback (older phaser might not have
drawRoundRect)
3. alwaysOn to skip mouse hover events
4. simulateOnHoverOver / simulateOnHoverOut methods to simulate the
hover event (to make use of the fadeout / fadein).

Thank you for your consideration.