### PR TITLE
alwaysOn option renamed to disableInputEvents and bug fix for the now "disableInputEvents"

### DIFF
--- a/Phasetips.js
+++ b/Phasetips.js
@@ -113,9 +113,9 @@ var Phasetips = function(localGame, options) {
         var _animationSpeedHide = _options.animationSpeedHide || 200;
         var _onHoverCallback = _options.onHoverCallback || function() {};
         var _onOutCallback = _options.onOutCallback || function() {};
-        // If alwaysOn option is set to true, the tooltip will not fade in or out upon hover.
+        // If disableInputEvents option is set to true, PHASETIPS will not add input events.
         // Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip methods to manually control the visibility.
-        var _alwaysOn = _options.alwaysOn || false;
+        var _disableInputEvents = _options.disableInputEvents || false;
 
         _options.animation = _animation;
         _options.animationDelay = _animationDelay;
@@ -265,12 +265,12 @@ var Phasetips = function(localGame, options) {
         //mainGroup.add(debug);
 
         // add event listener
-        _object.inputEnabled = true;
-        if (_enableCursor) {
-            _object.input.useHandCursor = true;
-        }
-
-        if(_this.alwaysOn !== true) {
+        // if "disableInputEvents" option is set to true, the followings are ignored.
+        if(_disableInputEvents !== true) {
+            _object.inputEnabled = true;
+            if (_enableCursor) {
+                _object.input.useHandCursor = true;
+            }
             _object.events.onInputOver.add(_this.onHoverOver, this);
             _object.events.onInputDown.add(_this.onHoverOver, this);
             _object.events.onInputOut.add(_this.onHoverOut, this);

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The game instance that we want the tooltips to appear to, such as "game"
     <li><strong>position: </strong> The position of the tooltip based on the targetObject (default: top, options: top, bottom, left, right)</li>
     <li><strong>targetObject:</strong> The actual object in which the tooltip will appear on hover (default: Game)</li>
     <li><strong>enableCursor: </strong> Enables the hand-cursor over the target object when hovered (default: false)</li>
-    <li><strong>alwaysOn:</strong> If alwaysOn option is set to true, the tooltip will neither fade in nor out upon hover. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
+    <li><strong>disableInputEvents:</strong> If disableInputEvents option is set to true, the tooltip will not add will not add input events. Use simulateOnHoverOver, simulateOnHoverOut, hideTooltip or showTooltip API functions to manually control the visibility. (Default: false)</li>
 </ul>
 
 <strong>Animation Options:</strong>


### PR DESCRIPTION
Sorry but I wanted to change the name of alwaysOn to disableInputEvents which better describe what the option does.

And the option was not working because of my misunderstanding the scope of variable, _this.

Thank you very much for your consideration!