### PR TITLE
FIX : error caused when x or y is set in the option

### DIFF
--- a/Phasetips.js
+++ b/Phasetips.js
@@ -178,6 +178,7 @@ var Phasetips = function(localGame, options) {
         //////////////////////
         function updatePosition() {
             var _origPosition = _position;
+            var worldPos = _options.targetObject ? _options.targetObject.world : game.world;
             if (_x !== "auto" && _y !== "auto") {
                 mainGroup.x = _x;
                 mainGroup.y = _y;
@@ -186,7 +187,6 @@ var Phasetips = function(localGame, options) {
                     mainGroup.cameraOffset.setTo(mainGroup.x, mainGroup.y);
                 }
             } else {
-                var worldPos = _options.targetObject ? _options.targetObject.world : game.world;
                 objectX = worldPos.x || _options.targetObject.x;
                 objectY = worldPos.y || _options.targetObject.y;
 


### PR DESCRIPTION
There might be something wrong with how I use, do you see any errors when x or y is set in the option? (In console, I see an error in trying to read a property of worldPos worldPos)

I moved the following line to just before the conditional stateements as a workaround.

```
var worldPos = _options.targetObject ? _options.targetObject.world : game.world;
```

My sample tooltip code : 

```
var testtip = new Phasetips(Game, {
			context: "Please enter your nickname to start game.",
			font: "Josefin Sans",
			fontSize: 24,
			width: 180,
			fontStroke: "#f45212",
			fontFill: "#f8ce18",
			backgroundColor: 0xf45212,
			strokeColor: 0xf8ce18,
			strokeWeight: 5,
			roundedCornersRadius: 10,
			x: 100,
			y: 100,
			disableInputEvents: true,
		});
```

Please review if this is okay. Thank you for your time in advance!